### PR TITLE
Baseline plugin autoremediate

### DIFF
--- a/examples/baseline_plugin.config.yaml
+++ b/examples/baseline_plugin.config.yaml
@@ -6,4 +6,5 @@ bigfix:
         trigger_file_path: baseline_plugin_run_now
         sites:
           - name: Updates for Windows Applications Extended
+            # auto_remediate: true
           - name: Updates for Windows Applications

--- a/examples/baseline_plugin.config.yaml
+++ b/examples/baseline_plugin.config.yaml
@@ -8,4 +8,4 @@ bigfix:
           - name: Updates for Windows Applications Extended
             auto_remediate: true
             offer_action: true
-          # - name: Updates for Windows Applications
+          - name: Updates for Windows Applications

--- a/examples/baseline_plugin.config.yaml
+++ b/examples/baseline_plugin.config.yaml
@@ -6,5 +6,6 @@ bigfix:
         trigger_file_path: baseline_plugin_run_now
         sites:
           - name: Updates for Windows Applications Extended
-            # auto_remediate: true
-          - name: Updates for Windows Applications
+            auto_remediate: true
+            offer_action: true
+          # - name: Updates for Windows Applications

--- a/examples/baseline_plugin.py
+++ b/examples/baseline_plugin.py
@@ -195,7 +195,7 @@ def create_baseline_from_site(site):
 
             offer_xml = ""
 
-            offer_action = site["offer_action"] if "offer_action" in site else False
+            offer_action = site["offer_action"] if "offer_action" in site else True
 
             if offer_action:
                 offer_xml = """<IsOffer>true</IsOffer>


### PR DESCRIPTION
Baseline plugin autoremediate

This does not have the option to create MAGs instead of baselines currently.

This also does not cleanup existing actions or baselines currently.

Otherwise this supports auto remediation or auto offers.